### PR TITLE
Add LazyHydrate plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ pnpm install
 pnpm dev
 ```
 
+## Hydratation partielle
+
+Le plugin `islands.client.ts` enregistre globalement le composant `LazyHydrate`.
+Celui‑ci permet de différer l'hydratation d'une portion de page.
+
+```vue
+<template>
+  <LazyHydrate when-visible>
+    <Slider />
+  </LazyHydrate>
+</template>
+```
+
 ## Tests
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "vitest": "^1.0.0",
     "vue": "^3.5.16"
   },
-  "packageManager": "pnpm@8.15.0+sha512.ea45517d5285d123eac02c3793505fa1fd6da90a2fc60d1e8d9e0c1e9292886ecfaff513f062b9d1cc8021bb8615033b1ac5bea3b2ee3fc165a6d7034bbe6b03"
+  "packageManager": "pnpm@8.15.0+sha512.ea45517d5285d123eac02c3793505fa1fd6da90a2fc60d1e8d9e0c1e9292886ecfaff513f062b9d1cc8021bb8615033b1ac5bea3b2ee3fc165a6d7034bbe6b03",
+  "dependencies": {
+    "vue-lazy-hydration": "2.0.0-beta.4"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      vue-lazy-hydration:
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4
     devDependencies:
       '@nuxt/devtools':
         specifier: ^2.5.0
@@ -10364,6 +10368,10 @@ packages:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.16(typescript@5.8.3)
     dev: true
+
+  /vue-lazy-hydration@2.0.0-beta.4:
+    resolution: {integrity: sha512-bhr7AxzrSEPed4cOawIeCxJmR8pglberR78x1zs0886xR+47/EXE9s0Ezss90CPINo8ApzUfA/r+SbNffn+t9w==}
+    dev: false
 
   /vue-router@4.5.1(vue@3.5.16):
     resolution: {integrity: sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==}

--- a/src/plugins/islands.client.spec.ts
+++ b/src/plugins/islands.client.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+vi.mock('#app', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defineNuxtPlugin: (fn: any) => fn
+}))
+
+import plugin from './islands.client'
+import LazyHydrate from 'vue-lazy-hydration'
+
+describe('islands plugin', () => {
+  it('registers LazyHydrate component', () => {
+    const component = vi.fn()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nuxtApp = { vueApp: { component } } as any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(plugin as any)(nuxtApp)
+    expect(component).toHaveBeenCalledWith('LazyHydrate', LazyHydrate)
+  })
+})

--- a/src/plugins/islands.client.ts
+++ b/src/plugins/islands.client.ts
@@ -1,3 +1,6 @@
-export default defineNuxtPlugin(() => {
-  // TODO: implement islands hydration
+import { defineNuxtPlugin } from '#app'
+import LazyHydrate from 'vue-lazy-hydration'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component('LazyHydrate', LazyHydrate)
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '#app': fileURLToPath(new URL('./node_modules/nuxt/dist/app', import.meta.url))
     }
   },
   test: {


### PR DESCRIPTION
## Summary
- implement islands plugin with LazyHydrate for partial hydration
- document how to use the LazyHydrate component
- add a small unit test
- alias `#app` in Vitest

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684c3866c0cc8333a690793870e2353d