### PR TITLE
Implement UI components

### DIFF
--- a/src/components/Card.spec.ts
+++ b/src/components/Card.spec.ts
@@ -7,4 +7,9 @@ describe('Card', () => {
     const wrapper = mount(Card, { slots: { default: 'Hello' } })
     expect(wrapper.text()).toBe('Hello')
   })
+
+  it('applies variant classes', () => {
+    const wrapper = mount(Card, { props: { variant: 'primary' }, slots: { default: 'hi' } })
+    expect(wrapper.classes()).toContain('border-blue-500')
+  })
 })

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -1,9 +1,27 @@
 <template>
-  <div class="p-4 border rounded">
+  <div
+    class="p-4 border rounded"
+    :class="variant === 'primary' ? 'border-blue-500 bg-blue-50' : ''"
+  >
     <slot />
   </div>
 </template>
 
 <script setup lang="ts">
-// TODO: add props
+import { toRefs } from 'vue'
+import type { PropType } from 'vue'
+
+export interface CardProps {
+  variant?: 'default' | 'primary'
+}
+
+const props = defineProps({
+  variant: {
+    type: String as PropType<CardProps['variant']>,
+    default: 'default',
+    validator: (value: string) => ['default', 'primary'].includes(value)
+  }
+})
+
+const { variant } = toRefs(props)
 </script>

--- a/src/components/LazyExample.spec.ts
+++ b/src/components/LazyExample.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import LazyExample from './LazyExample.vue'
+
+describe('LazyExample', () => {
+  it('increments on click', async () => {
+    const wrapper = mount(LazyExample)
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.text()).toContain('1')
+  })
+})

--- a/src/components/LazyExample.vue
+++ b/src/components/LazyExample.vue
@@ -1,6 +1,13 @@
 <template>
-  <div v-lazy-hydrate>lazy hydrated component</div>
+  <div v-lazy-hydrate>
+    <button class="px-2 py-1 bg-gray-200 rounded" @click="count++">
+      Clicked {{ count }} times
+    </button>
+  </div>
 </template>
+
 <script setup lang="ts">
-// TODO: implement
+import { ref } from 'vue'
+
+const count = ref(0)
 </script>

--- a/src/components/Slider.client.spec.ts
+++ b/src/components/Slider.client.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import Slider from './Slider.client.vue'
+
+describe('Slider', () => {
+  it('cycles slides', async () => {
+    const wrapper = mount(Slider, { props: { slides: ['A', 'B'] } })
+    expect(wrapper.text()).toContain('A')
+    await wrapper.find('button.next').trigger('click')
+    expect(wrapper.text()).toContain('B')
+    await wrapper.find('button.prev').trigger('click')
+    expect(wrapper.text()).toContain('A')
+  })
+})

--- a/src/components/Slider.client.vue
+++ b/src/components/Slider.client.vue
@@ -1,6 +1,31 @@
 <template>
-  <div>client-only slider TODO</div>
+  <div class="space-y-2">
+    <div class="p-4 border rounded min-h-[2rem] flex items-center justify-center">
+      {{ slides[current] }}
+    </div>
+    <div class="flex gap-2">
+      <button class="px-2 py-1 border rounded prev" @click="prev">
+        Prev
+      </button>
+      <button class="px-2 py-1 border rounded next" @click="next">
+        Next
+      </button>
+    </div>
+  </div>
 </template>
+
 <script setup lang="ts">
-// hydration: client-only
+import { ref } from 'vue'
+
+const props = defineProps<{ slides: string[] }>()
+
+const current = ref(0)
+
+function next() {
+  current.value = (current.value + 1) % props.slides.length
+}
+
+function prev() {
+  current.value = (current.value - 1 + props.slides.length) % props.slides.length
+}
 </script>


### PR DESCRIPTION
## Summary
- add prop validation for Card component
- implement LazyExample logic
- create functional client-only Slider
- test Card variants and new components

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684c38629a408333a54ec31c5c6e0f86