### PR TITLE
Add runtime config and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ pnpm dev
 pnpm test -- --run
 ```
 
+## Variables d'environnement
+
+Le projet s'appuie sur plusieurs variables pour son runtime :
+
+- `STRAPI_URL` — URL de l'instance Strapi utilisée par l'application.
+- `STRAPI_TOKEN` — jeton d'authentification Strapi (utilisé côté serveur).
+- `NUXT_PUBLIC_PLAUSIBLE_DOMAIN` — domaine suivi par Plausible Analytics.
+- `NUXT_PUBLIC_SITE_URL` — URL publique du site pour le SEO.
+- `FIGMA_TOKEN` — jeton utilisé pour générer les design tokens.
+
 ## Déploiement
 - GitHub Pages via `deploy-static.yml`
 - Vercel / Render

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,5 +13,12 @@ export default defineNuxtConfig({
     '@nuxt/devtools',
     '@vueuse/nuxt'
   ],
-  // TODO: add runtime config and other settings
+  runtimeConfig: {
+    strapiToken: process.env.STRAPI_TOKEN,
+    public: {
+      strapiUrl: process.env.STRAPI_URL || 'http://localhost:1337',
+      plausibleDomain: process.env.NUXT_PUBLIC_PLAUSIBLE_DOMAIN,
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- expose runtimeConfig in Nuxt config with public and private fields
- list expected environment variables in README

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684c3854b3048333a17fceeecf44d271