### PR TITLE
Increase Node heap for build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
           version: 8
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
-      - run: pnpm build
+      - run: NODE_OPTIONS="--max_old_space_size=6144" pnpm build
       - run: pnpm test || true


### PR DESCRIPTION
## Summary
- bump Node memory for the build step in CI

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684c55d0fe388333a136e2e47f70e407