### PR TITLE
Add simple tests for pages and API types

### DIFF
--- a/src/api/client.spec.ts
+++ b/src/api/client.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expectTypeOf } from 'vitest'
+import type { paths, operations } from './client'
+
+describe('API client types', () => {
+  it('exposes prompt text endpoint', () => {
+    expectTypeOf<paths>().toHaveProperty('/prompt/text')
+  })
+
+  it('maps get operation to prompt', () => {
+    expectTypeOf<paths['/prompt/text']['get']>().toEqualTypeOf<operations['prompt']>()
+  })
+})

--- a/src/pages/index.spec.ts
+++ b/src/pages/index.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import IndexPage from './index.vue'
+
+describe('Index page', () => {
+  it('renders welcome text', () => {
+    const wrapper = mount(IndexPage)
+    expect(wrapper.text()).toContain('Welcome to Nudger !')
+  })
+})


### PR DESCRIPTION
## Summary
- add a test for the index page
- add a type test for the OpenAPI client

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684c560c743083339af7e7bf1661c4cb