### PR TITLE
Optimize SSR build configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,11 +11,14 @@ export default defineNuxtConfig({
     '@nuxtjs/sitemap',
     '@nuxtjs/robots',
     '@nuxt/image',
-    '@nuxt/devtools',
-    '@nuxtjs/storybook',
+    process.env.NODE_ENV !== 'production' && '@nuxt/devtools',
+    process.env.NODE_ENV !== 'production' && '@nuxtjs/storybook',
     '@vueuse/nuxt',
     '@vite-pwa/nuxt'
-  ],
+  ].filter(Boolean),
+  devtools: {
+    enabled: process.env.NODE_ENV !== 'production'
+  },
   i18n: {
     locales: [
       { code: 'en', iso: 'en-US', name: 'English' },
@@ -49,9 +52,13 @@ export default defineNuxtConfig({
         }
       ]
     }
-  }
-  ,vite: {
+  },
+  vite: {
     workerThreads: true,
+    cacheDir: '.nuxt/.vite-cache',
+    ssr: {
+      noExternal: ['vue-lazy-hydration', '@nuxthq/ui']
+    },
     resolve: {
       alias: {
         vue: 'vue/dist/vue.runtime.esm-bundler.js'

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",
+    "build:ssr": "NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
     "generate": "nuxt generate",
     "lint": "eslint . --ext .ts,.vue",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- conditionally register devtools and storybook modules
- enable devtools only in dev builds
- cache Vite build artifacts and avoid transpiling heavy modules
- add build script with higher memory limit

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_684c8528e5b483338176042299ccd9d5