### PR TITLE
Document NODE_OPTIONS in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ pnpm install
 pnpm dev
 ```
 
+## Build
+
+La compilation requiert davantage de mémoire pour Node.js. Le script `pnpm build` définit automatiquement `NODE_OPTIONS='--max-old-space-size=8192'`.
+
+```bash
+pnpm build
+```
+
 ## PWA
 
 L'application peut être installée comme une Progressive Web App. Le service worker et le manifeste sont gérés par le module `@vite-pwa/nuxt`.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "dev": "nuxt dev",
-    "build": "nuxt build",
-    "build:ssr": "NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
+    "build:ssr": "pnpm build",
     "generate": "nuxt generate",
     "lint": "eslint . --ext .ts,.vue",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- set `NODE_OPTIONS='--max-old-space-size=8192'` in the build script
- alias `build:ssr` to `pnpm build`
- add Build instructions in the README

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_684c907c7ab88333a289d45fa9b28a1d