### PR TITLE
Use corepack for pnpm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
         with:
-          version: 8
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack prepare pnpm@10.12.1 --activate
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm build

--- a/.github/workflows/deploy-ssr.yml
+++ b/.github/workflows/deploy-ssr.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
         with:
-          version: 8
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack prepare pnpm@10.12.1 --activate
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Deploy via rsync

--- a/.github/workflows/deploy-static.yml
+++ b/.github/workflows/deploy-static.yml
@@ -8,9 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
         with:
-          version: 8
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack prepare pnpm@10.12.1 --activate
       - run: pnpm install --frozen-lockfile
       - run: pnpm generate
       - uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
         with:
-          version: 8
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack prepare pnpm@10.12.1 --activate
       - run: pnpm install --frozen-lockfile
       - run: pnpm semantic-release

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
         with:
-          version: 8
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack prepare pnpm@10.12.1 --activate
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm storybook:build


### PR DESCRIPTION
## Summary
- manage pnpm via corepack in all CI workflows
- ensure the required pnpm version is downloaded and activated

## Testing
- `pnpm lint` *(fails: plugin:vue/vue3-recommended not found)*
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_684d364d37b88333a395b4cdb7ad7624